### PR TITLE
Don't Release Unverified Plain Text (RUP)

### DIFF
--- a/include/verf_dec.hpp
+++ b/include/verf_dec.hpp
@@ -32,7 +32,15 @@ decrypt_128(const secret_key_128_t& k,
   process_ciphertext<6, 64>(state, cipher, cipher_len, text);
 
   const tag_t t_ = finalize<12, 64>(state, k);
-  return (t.limbs[0] == t_.limbs[0]) && (t.limbs[1] == t_.limbs[1]);
+
+  const uint64_t flg0 = t.limbs[0] ^ t_.limbs[0];
+  const uint64_t flg1 = t.limbs[1] ^ t_.limbs[1];
+
+  const bool flg = static_cast<bool>(flg0 | flg1);
+
+  std::memset(text, 0, flg * cipher_len);
+
+  return !flg;
 }
 
 // Decrypts cipher text with Ascon-128a verified decryption algorithm; see
@@ -62,7 +70,15 @@ decrypt_128a(const secret_key_128_t& k,
   process_ciphertext<8, 128>(state, cipher, cipher_len, text);
 
   const tag_t t_ = finalize<12, 128>(state, k);
-  return (t.limbs[0] == t_.limbs[0]) && (t.limbs[1] == t_.limbs[1]);
+
+  const uint64_t flg0 = t.limbs[0] ^ t_.limbs[0];
+  const uint64_t flg1 = t.limbs[1] ^ t_.limbs[1];
+
+  const bool flg = static_cast<bool>(flg0 | flg1);
+
+  std::memset(text, 0, flg * cipher_len);
+
+  return !flg;
 }
 
 // Decrypts cipher text with Ascon-80pq verified decryption algorithm; see
@@ -92,7 +108,15 @@ decrypt_80pq(const secret_key_160_t& k,
   process_ciphertext<6, 64>(state, cipher, cipher_len, text);
 
   const tag_t t_ = finalize<12, 64>(state, k);
-  return (t.limbs[0] == t_.limbs[0]) && (t.limbs[1] == t_.limbs[1]);
+
+  const uint64_t flg0 = t.limbs[0] ^ t_.limbs[0];
+  const uint64_t flg1 = t.limbs[1] ^ t_.limbs[1];
+
+  const bool flg = static_cast<bool>(flg0 | flg1);
+
+  std::memset(text, 0, flg * cipher_len);
+
+  return !flg;
 }
 
 }

--- a/wrapper/python/ascon.py
+++ b/wrapper/python/ascon.py
@@ -237,8 +237,6 @@ def decrypt_128(
     # decrypt using Ascon-128
     v = SO_LIB.decrypt_128(key_, nonce_, data, d_len, cipher, c_len, text, tag_)
 
-    assert v, "tag doesn't match, failed to decrypt !"
-
     # return decryption status, decrypted plain text
     return v, text
 
@@ -360,8 +358,6 @@ def decrypt_128a(
 
     # decrypt using Ascon-128a
     v = SO_LIB.decrypt_128a(key_, nonce_, data, d_len, cipher, c_len, text, tag_)
-
-    assert v, "tag doesn't match, failed to decrypt !"
 
     # return decryption status, decrypted plain text
     return v, text
@@ -487,11 +483,9 @@ def decrypt_80pq(
     # decrypt using Ascon-80pq
     v = SO_LIB.decrypt_80pq(key_, nonce_, data, d_len, cipher, c_len, text, tag_)
 
-    assert v, "tag doesn't match, failed to decrypt !"
-
     # return decryption status, decrypted plain text
     return v, text
 
 
 if __name__ == "__main__":
-    print("This is an importable library module !")
+    print("Use `ascon` as library module !")


### PR DESCRIPTION
When authentication fails during verified decryption,

- don't release unverified plain text
- `memset` plain text memory allocation to zero bytes
- test that this behaviour works fine for Ascon128, Ascon128a & Ascon80pq