### PR TITLE
Add Constants for AEAD Key, Nonce, Tag Length/ Hash Digest Length

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,16 @@ $ pushd wrapper/python
 $ python3 # consider enabling `venv`
 
 >>> import ascon
+>>> import random
 >>> ascon.hash(b'').hex()               # computing ascon-hash digest
 '7346bc14f036e87ae03d0997913088f5f68411434b3cf8b54fa796a80d251f91'
->>>
+>>> key = random.randbytes(16)
+>>> nonce = random.randbytes(16)
+>>> msg = b'abcd'
+>>> enc, tag = ascon.encrypt_128a(key, nonce, b'', msg)
+>>> verf, dec = ascon.decrypt_128a(key, nonce, b'', enc, tag)
+>>> assert verf
+>>> assert msg == dec
 
 $ popd
 ```

--- a/example/ascon_128.cpp
+++ b/example/ascon_128.cpp
@@ -12,24 +12,21 @@ main()
   constexpr size_t dlen = 32;  // bytes
 
   // acquire resources
-  uint8_t* key = static_cast<uint8_t*>(malloc(16));     // secret key
-  uint8_t* nonce = static_cast<uint8_t*>(malloc(16));   // message nonce
-  uint8_t* tag = static_cast<uint8_t*>(malloc(16));     // authentication tag
+  uint8_t* key = static_cast<uint8_t*>(malloc(ascon::ASCON128_KEY_LEN));
+  uint8_t* nonce = static_cast<uint8_t*>(malloc(ascon::ASCON128_NONCE_LEN));
+  uint8_t* tag = static_cast<uint8_t*>(malloc(ascon::ASCON128_TAG_LEN));
   uint8_t* data = static_cast<uint8_t*>(malloc(dlen));  // associated data
   uint8_t* text = static_cast<uint8_t*>(malloc(ctlen)); // plain text
   uint8_t* enc = static_cast<uint8_t*>(malloc(ctlen));  // ciphered text
   uint8_t* dec = static_cast<uint8_t*>(malloc(ctlen));  // deciphered text
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128_NONCE_LEN);
   ascon_utils::random_data(text, ctlen);
   ascon_utils::random_data(data, dlen);
 
-  // using Ascon-128 for running encrypt -> decrypt cycle
-  using namespace ascon;
-
-  encrypt_128(key, nonce, data, dlen, text, ctlen, enc, tag);
-  bool f = decrypt_128(key, nonce, data, dlen, enc, ctlen, dec, tag);
+  ascon::encrypt_128(key, nonce, data, dlen, text, ctlen, enc, tag);
+  bool f = ascon::decrypt_128(key, nonce, data, dlen, enc, ctlen, dec, tag);
 
   assert(f);
 

--- a/example/ascon_128a.cpp
+++ b/example/ascon_128a.cpp
@@ -12,24 +12,21 @@ main()
   constexpr size_t dlen = 32;  // bytes
 
   // acquire resources
-  uint8_t* key = static_cast<uint8_t*>(malloc(16));     // secret key
-  uint8_t* nonce = static_cast<uint8_t*>(malloc(16));   // message nonce
-  uint8_t* tag = static_cast<uint8_t*>(malloc(16));     // authentication tag
+  uint8_t* key = static_cast<uint8_t*>(malloc(ascon::ASCON128A_KEY_LEN));
+  uint8_t* nonce = static_cast<uint8_t*>(malloc(ascon::ASCON128A_NONCE_LEN));
+  uint8_t* tag = static_cast<uint8_t*>(malloc(ascon::ASCON128A_TAG_LEN));
   uint8_t* data = static_cast<uint8_t*>(malloc(dlen));  // associated data
   uint8_t* text = static_cast<uint8_t*>(malloc(ctlen)); // plain text
   uint8_t* enc = static_cast<uint8_t*>(malloc(ctlen));  // ciphered text
   uint8_t* dec = static_cast<uint8_t*>(malloc(ctlen));  // deciphered text
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128A_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128A_NONCE_LEN);
   ascon_utils::random_data(text, ctlen);
   ascon_utils::random_data(data, dlen);
 
-  // using Ascon-128a for running encrypt -> decrypt cycle
-  using namespace ascon;
-
-  encrypt_128a(key, nonce, data, dlen, text, ctlen, enc, tag);
-  bool f = decrypt_128a(key, nonce, data, dlen, enc, ctlen, dec, tag);
+  ascon::encrypt_128a(key, nonce, data, dlen, text, ctlen, enc, tag);
+  bool f = ascon::decrypt_128a(key, nonce, data, dlen, enc, ctlen, dec, tag);
 
   assert(f);
 

--- a/example/ascon_80pq.cpp
+++ b/example/ascon_80pq.cpp
@@ -12,24 +12,21 @@ main()
   constexpr size_t dlen = 32;  // bytes
 
   // acquire resources
-  uint8_t* key = static_cast<uint8_t*>(malloc(20));     // secret key
-  uint8_t* nonce = static_cast<uint8_t*>(malloc(16));   // message nonce
-  uint8_t* tag = static_cast<uint8_t*>(malloc(16));     // authentication tag
+  uint8_t* key = static_cast<uint8_t*>(malloc(ascon::ASCON80PQ_KEY_LEN));
+  uint8_t* nonce = static_cast<uint8_t*>(malloc(ascon::ASCON80PQ_NONCE_LEN));
+  uint8_t* tag = static_cast<uint8_t*>(malloc(ascon::ASCON80PQ_TAG_LEN));
   uint8_t* data = static_cast<uint8_t*>(malloc(dlen));  // associated data
   uint8_t* text = static_cast<uint8_t*>(malloc(ctlen)); // plain text
   uint8_t* enc = static_cast<uint8_t*>(malloc(ctlen));  // ciphered text
   uint8_t* dec = static_cast<uint8_t*>(malloc(ctlen));  // deciphered text
 
-  ascon_utils::random_data(key, 20);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON80PQ_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON80PQ_NONCE_LEN);
   ascon_utils::random_data(text, ctlen);
   ascon_utils::random_data(data, dlen);
 
-  // using Ascon-80pq for running encrypt -> decrypt cycle
-  using namespace ascon;
-
-  encrypt_80pq(key, nonce, data, dlen, text, ctlen, enc, tag);
-  bool f = decrypt_80pq(key, nonce, data, dlen, enc, ctlen, dec, tag);
+  ascon::encrypt_80pq(key, nonce, data, dlen, text, ctlen, enc, tag);
+  bool f = ascon::decrypt_80pq(key, nonce, data, dlen, enc, ctlen, dec, tag);
 
   assert(f);
 

--- a/example/ascon_hash.cpp
+++ b/example/ascon_hash.cpp
@@ -8,18 +8,17 @@ int
 main()
 {
   constexpr size_t msg_len = 64; // bytes
-  constexpr size_t out_len = 32; // bytes
 
   // acquire resources
   uint8_t* msg = static_cast<uint8_t*>(malloc(msg_len)); // input
-  uint8_t* out = static_cast<uint8_t*>(malloc(out_len)); // digest
+  uint8_t* out = static_cast<uint8_t*>(malloc(ascon::DIGEST_LEN));
 
   ascon_utils::random_data(msg, msg_len);
   ascon::hash(msg, msg_len, out);
 
   std::cout << "Ascon Hash\n\n";
   std::cout << "Message :\t" << ascon_utils::to_hex(msg, msg_len) << "\n";
-  std::cout << "Digest  :\t" << ascon_utils::to_hex(out, out_len) << "\n";
+  std::cout << "Digest  :\t" << ascon_utils::to_hex(out, 32) << "\n";
 
   // deallocate resources
   free(msg);

--- a/example/ascon_hasha.cpp
+++ b/example/ascon_hasha.cpp
@@ -8,18 +8,17 @@ int
 main()
 {
   constexpr size_t msg_len = 64; // bytes
-  constexpr size_t out_len = 32; // bytes
 
   // acquire resources
-  uint8_t* msg = static_cast<uint8_t*>(malloc(msg_len)); // input
-  uint8_t* out = static_cast<uint8_t*>(malloc(out_len)); // digest
+  uint8_t* msg = static_cast<uint8_t*>(malloc(msg_len));           // input
+  uint8_t* out = static_cast<uint8_t*>(malloc(ascon::DIGEST_LEN)); // digest
 
   ascon_utils::random_data(msg, msg_len);
   ascon::hash_a(msg, msg_len, out);
 
   std::cout << "Ascon HashA\n\n";
   std::cout << "Message :\t" << ascon_utils::to_hex(msg, msg_len) << "\n";
-  std::cout << "Digest  :\t" << ascon_utils::to_hex(out, out_len) << "\n";
+  std::cout << "Digest  :\t" << ascon_utils::to_hex(out, 32) << "\n";
 
   // deallocate resources
   free(msg);

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -1,3 +1,5 @@
 #pragma once
+
 #include "auth_enc.hpp"
+#include "consts.hpp"
 #include "verf_dec.hpp"

--- a/include/bench/bench_aead.hpp
+++ b/include/bench/bench_aead.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "aead.hpp"
+#include "consts.hpp"
 #include <benchmark/benchmark.h>
 #include <cassert>
 
@@ -13,15 +14,15 @@ enc_128(benchmark::State& state)
   const size_t ct_len = static_cast<size_t>(state.range(0));
   const size_t dt_len = static_cast<size_t>(state.range(1));
 
-  uint8_t* key = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* nonce = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* data = static_cast<uint8_t*>(std::malloc(dt_len));
-  uint8_t* text = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* enc = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* tag = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_TAG_LEN));
+  auto data = static_cast<uint8_t*>(std::malloc(dt_len));
+  auto text = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto enc = static_cast<uint8_t*>(std::malloc(ct_len));
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128_NONCE_LEN);
   ascon_utils::random_data(data, dt_len);
   ascon_utils::random_data(text, ct_len);
 
@@ -60,16 +61,16 @@ dec_128(benchmark::State& state)
   const size_t ct_len = static_cast<size_t>(state.range(0));
   const size_t dt_len = static_cast<size_t>(state.range(1));
 
-  uint8_t* key = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* nonce = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* data = static_cast<uint8_t*>(std::malloc(dt_len));
-  uint8_t* text = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* enc = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* dec = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* tag = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_TAG_LEN));
+  auto data = static_cast<uint8_t*>(std::malloc(dt_len));
+  auto text = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto enc = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto dec = static_cast<uint8_t*>(std::malloc(ct_len));
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128_NONCE_LEN);
   ascon_utils::random_data(data, dt_len);
   ascon_utils::random_data(text, ct_len);
 
@@ -112,15 +113,15 @@ enc_128a(benchmark::State& state)
   const size_t ct_len = static_cast<size_t>(state.range(0));
   const size_t dt_len = static_cast<size_t>(state.range(1));
 
-  uint8_t* key = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* nonce = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* data = static_cast<uint8_t*>(std::malloc(dt_len));
-  uint8_t* text = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* enc = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* tag = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_TAG_LEN));
+  auto data = static_cast<uint8_t*>(std::malloc(dt_len));
+  auto text = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto enc = static_cast<uint8_t*>(std::malloc(ct_len));
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128A_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128A_NONCE_LEN);
   ascon_utils::random_data(data, dt_len);
   ascon_utils::random_data(text, ct_len);
 
@@ -159,16 +160,16 @@ dec_128a(benchmark::State& state)
   const size_t ct_len = static_cast<size_t>(state.range(0));
   const size_t dt_len = static_cast<size_t>(state.range(1));
 
-  uint8_t* key = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* nonce = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* data = static_cast<uint8_t*>(std::malloc(dt_len));
-  uint8_t* text = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* enc = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* dec = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* tag = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_TAG_LEN));
+  auto data = static_cast<uint8_t*>(std::malloc(dt_len));
+  auto text = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto enc = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto dec = static_cast<uint8_t*>(std::malloc(ct_len));
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128A_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128A_NONCE_LEN);
   ascon_utils::random_data(data, dt_len);
   ascon_utils::random_data(text, ct_len);
 
@@ -211,15 +212,15 @@ enc_80pq(benchmark::State& state)
   const size_t ct_len = static_cast<size_t>(state.range(0));
   const size_t dt_len = static_cast<size_t>(state.range(1));
 
-  uint8_t* key = static_cast<uint8_t*>(std::malloc(20));
-  uint8_t* nonce = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* data = static_cast<uint8_t*>(std::malloc(dt_len));
-  uint8_t* text = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* enc = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* tag = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_TAG_LEN));
+  auto data = static_cast<uint8_t*>(std::malloc(dt_len));
+  auto text = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto enc = static_cast<uint8_t*>(std::malloc(ct_len));
 
-  ascon_utils::random_data(key, 20);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON80PQ_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON80PQ_NONCE_LEN);
   ascon_utils::random_data(data, dt_len);
   ascon_utils::random_data(text, ct_len);
 
@@ -258,16 +259,16 @@ dec_80pq(benchmark::State& state)
   const size_t ct_len = static_cast<size_t>(state.range(0));
   const size_t dt_len = static_cast<size_t>(state.range(1));
 
-  uint8_t* key = static_cast<uint8_t*>(std::malloc(20));
-  uint8_t* nonce = static_cast<uint8_t*>(std::malloc(16));
-  uint8_t* data = static_cast<uint8_t*>(std::malloc(dt_len));
-  uint8_t* text = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* enc = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* dec = static_cast<uint8_t*>(std::malloc(ct_len));
-  uint8_t* tag = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_TAG_LEN));
+  auto data = static_cast<uint8_t*>(std::malloc(dt_len));
+  auto text = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto enc = static_cast<uint8_t*>(std::malloc(ct_len));
+  auto dec = static_cast<uint8_t*>(std::malloc(ct_len));
 
-  ascon_utils::random_data(key, 20);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON80PQ_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON80PQ_NONCE_LEN);
   ascon_utils::random_data(data, dt_len);
   ascon_utils::random_data(text, ct_len);
 

--- a/include/bench/bench_hash.hpp
+++ b/include/bench/bench_hash.hpp
@@ -5,9 +5,6 @@
 // Benchmark Ascon Light Weight Cryptography Implementation
 namespace bench_ascon {
 
-// 256 -bit Ascon digest
-constexpr size_t DIG_LEN = 32ul;
-
 // Benchmark Ascon-Hash on target CPU
 void
 hash(benchmark::State& state)
@@ -15,10 +12,9 @@ hash(benchmark::State& state)
   const size_t mlen = static_cast<size_t>(state.range(0));
 
   uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
-  uint8_t* digest = static_cast<uint8_t*>(std::malloc(DIG_LEN));
+  uint8_t* digest = static_cast<uint8_t*>(std::malloc(ascon::DIGEST_LEN));
 
   ascon_utils::random_data(msg, mlen);
-  std::memset(digest, 0, DIG_LEN);
 
   for (auto _ : state) {
     ascon::hash(msg, mlen, digest);
@@ -41,10 +37,9 @@ hash_a(benchmark::State& state)
   const size_t mlen = static_cast<size_t>(state.range(0));
 
   uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
-  uint8_t* digest = static_cast<uint8_t*>(std::malloc(DIG_LEN));
+  uint8_t* digest = static_cast<uint8_t*>(std::malloc(ascon::DIGEST_LEN));
 
   ascon_utils::random_data(msg, mlen);
-  std::memset(digest, 0, DIG_LEN);
 
   for (auto _ : state) {
     ascon::hash_a(msg, mlen, digest);

--- a/include/consts.hpp
+++ b/include/consts.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+// Ascon Light Weight Cryptography ( i.e. authenticated encryption, verified
+// decryption and hashing ) Implementation
+namespace ascon {
+
+// Ascon Hash{A} Digest Byte Length
+constexpr size_t DIGEST_LEN = 32;
+
+// Ascon-128 AEAD Key Byte Length
+constexpr size_t ASCON128_KEY_LEN = 16;
+
+// Ascon-128 AEAD Public Message Nonce Byte Length
+constexpr size_t ASCON128_NONCE_LEN = 16;
+
+// Ascon-128 AEAD Authentication Tag Byte Length
+constexpr size_t ASCON128_TAG_LEN = 16;
+
+// Ascon-128a AEAD Key Byte Length
+constexpr size_t ASCON128A_KEY_LEN = 16;
+
+// Ascon-128a AEAD Public Message Nonce Byte Length
+constexpr size_t ASCON128A_NONCE_LEN = 16;
+
+// Ascon-128a AEAD Authentication Tag Byte Length
+constexpr size_t ASCON128A_TAG_LEN = 16;
+
+// Ascon-80pq AEAD Key Byte Length
+constexpr size_t ASCON80PQ_KEY_LEN = 20;
+
+// Ascon-80pq AEAD Public Message Nonce Byte Length
+constexpr size_t ASCON80PQ_NONCE_LEN = 16;
+
+// Ascon-80pq AEAD Authentication Tag Byte Length
+constexpr size_t ASCON80PQ_TAG_LEN = 16;
+
+}

--- a/include/hash.hpp
+++ b/include/hash.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "consts.hpp"
 #include "hash_utils.hpp"
 #include <cstring>
 

--- a/include/test/test_cipher.hpp
+++ b/include/test/test_cipher.hpp
@@ -1,8 +1,6 @@
 #pragma once
-#include "auth_enc.hpp"
-#include "verf_dec.hpp"
+#include "aead.hpp"
 #include <cassert>
-#include <string.h>
 
 // Test Ascon Light Weight Cryptography Implementation
 namespace ascon_test {
@@ -14,16 +12,16 @@ ascon_128(const size_t dlen, // bytes; >= 0
           const size_t ctlen // bytes; >= 0
 )
 {
-  auto key = static_cast<uint8_t*>(std::malloc(16));
-  auto nonce = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON128_TAG_LEN));
   auto data = static_cast<uint8_t*>(std::malloc(dlen));
   auto text = static_cast<uint8_t*>(std::malloc(ctlen));
   auto enc = static_cast<uint8_t*>(std::malloc(ctlen));
   auto dec = static_cast<uint8_t*>(std::malloc(ctlen));
-  auto tag = static_cast<uint8_t*>(std::malloc(16));
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128_NONCE_LEN);
   ascon_utils::random_data(data, dlen);
   ascon_utils::random_data(text, ctlen);
 
@@ -52,16 +50,16 @@ ascon_128a(const size_t dlen, // bytes; >= 0
            const size_t ctlen // bytes; >= 0
 )
 {
-  auto key = static_cast<uint8_t*>(std::malloc(16));
-  auto nonce = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON128A_TAG_LEN));
   auto data = static_cast<uint8_t*>(std::malloc(dlen));
   auto text = static_cast<uint8_t*>(std::malloc(ctlen));
   auto enc = static_cast<uint8_t*>(std::malloc(ctlen));
   auto dec = static_cast<uint8_t*>(std::malloc(ctlen));
-  auto tag = static_cast<uint8_t*>(std::malloc(16));
 
-  ascon_utils::random_data(key, 16);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON128A_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON128A_NONCE_LEN);
   ascon_utils::random_data(data, dlen);
   ascon_utils::random_data(text, ctlen);
 
@@ -90,16 +88,16 @@ ascon_80pq(const size_t dlen, // bytes; >= 0
            const size_t ctlen // bytes; >= 0
 )
 {
-  auto key = static_cast<uint8_t*>(std::malloc(20));
-  auto nonce = static_cast<uint8_t*>(std::malloc(16));
+  auto key = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_KEY_LEN));
+  auto nonce = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_NONCE_LEN));
+  auto tag = static_cast<uint8_t*>(std::malloc(ascon::ASCON80PQ_TAG_LEN));
   auto data = static_cast<uint8_t*>(std::malloc(dlen));
   auto text = static_cast<uint8_t*>(std::malloc(ctlen));
   auto enc = static_cast<uint8_t*>(std::malloc(ctlen));
   auto dec = static_cast<uint8_t*>(std::malloc(ctlen));
-  auto tag = static_cast<uint8_t*>(std::malloc(16));
 
-  ascon_utils::random_data(key, 20);
-  ascon_utils::random_data(nonce, 16);
+  ascon_utils::random_data(key, ascon::ASCON80PQ_KEY_LEN);
+  ascon_utils::random_data(nonce, ascon::ASCON80PQ_NONCE_LEN);
   ascon_utils::random_data(data, dlen);
   ascon_utils::random_data(text, ctlen);
 

--- a/include/verf_dec.hpp
+++ b/include/verf_dec.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "cipher.hpp"
+#include "consts.hpp"
 
 // Ascon Light Weight Cryptography ( i.e. authenticated encryption, verified
 // decryption and hashing ) Implementation
@@ -33,7 +34,7 @@ decrypt_128(const uint8_t* const __restrict key,
   finalize<12, 64, 128>(state, key, tag_);
 
   bool flg = false;
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < ascon::ASCON128_TAG_LEN; i++) {
     flg |= static_cast<bool>(tag[i] ^ tag_[i]);
   }
 
@@ -69,7 +70,7 @@ decrypt_128a(const uint8_t* const __restrict key,
   finalize<12, 128, 128>(state, key, tag_);
 
   bool flg = false;
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < ascon::ASCON128_TAG_LEN; i++) {
     flg |= static_cast<bool>(tag[i] ^ tag_[i]);
   }
 
@@ -105,7 +106,7 @@ decrypt_80pq(const uint8_t* const __restrict key,
   finalize<12, 64, 160>(state, key, tag_);
 
   bool flg = false;
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < ascon::ASCON128_TAG_LEN; i++) {
     flg |= static_cast<bool>(tag[i] ^ tag_[i]);
   }
 


### PR DESCRIPTION
Adds compile-time constants for AEAD key/ nonce/ tag byte length and hash digest length --- ease it for library user.