### PR TITLE
Improve Ascon-{Hash, Xof, CXof} API

### DIFF
--- a/benches/bench_ascon_aead128.cpp
+++ b/benches/bench_ascon_aead128.cpp
@@ -47,8 +47,8 @@ ascon_aead128_encrypt(benchmark::State& state)
 
 BENCHMARK(ascon_aead128_encrypt)
   ->ArgsProduct({
-    { 32 },                     // Associated data
-    { 32, 256, 2'048, 16'384 }, // Plain text
+    { 32 },                             // Associated data
+    { 32, 256, 2 * 1'024, 16 * 1'024 }, // Plain text
   })
   ->ComputeStatistics("min", compute_min)
   ->ComputeStatistics("max", compute_max);

--- a/benches/bench_ascon_hash256.cpp
+++ b/benches/bench_ascon_hash256.cpp
@@ -40,7 +40,11 @@ bench_ascon_hash256(benchmark::State& state)
 
 BENCHMARK(bench_ascon_hash256)
   ->Name("ascon_hash256")
-  ->RangeMultiplier(8)
-  ->Range(32, 16 * 1'024)
+  ->ArgsProduct({ {
+    32,
+    64,
+    2 * 1'024,
+    16 * 1'024,
+  } })
   ->ComputeStatistics("min", compute_min)
   ->ComputeStatistics("max", compute_max);

--- a/benches/bench_ascon_hash256.cpp
+++ b/benches/bench_ascon_hash256.cpp
@@ -13,22 +13,17 @@ bench_ascon_hash256(benchmark::State& state)
 
   generate_random_data<uint8_t>(msg);
 
-  bool ret_val = true;
   for (auto _ : state) {
-    ascon_hash256::ascon_hash256_t hasher;
-
-    benchmark::DoNotOptimize(ret_val);
     benchmark::DoNotOptimize(msg);
     benchmark::DoNotOptimize(digest);
 
-    ret_val &= hasher.absorb(msg);
-    ret_val &= hasher.finalize();
-    ret_val &= hasher.digest(digest);
+    ascon_hash256::ascon_hash256_t hasher;
+    assert(hasher.absorb(msg) == ascon_hash256::ascon_hash256_status_t::absorbed_data);
+    assert(hasher.finalize() == ascon_hash256::ascon_hash256_status_t::finalized_data_absorption_phase);
+    assert(hasher.digest(digest) == ascon_hash256::ascon_hash256_status_t::message_digest_produced);
 
     benchmark::ClobberMemory();
   }
-
-  assert(ret_val);
 
   const size_t total_bytes_processed = msg.size() * state.iterations();
   state.SetBytesProcessed(total_bytes_processed);

--- a/benches/bench_ascon_xof128.cpp
+++ b/benches/bench_ascon_xof128.cpp
@@ -14,22 +14,17 @@ bench_ascon_xof128(benchmark::State& state)
 
   generate_random_data<uint8_t>(msg);
 
-  bool ret_val = true;
   for (auto _ : state) {
-    ascon_xof128::ascon_xof128_t hasher;
-
-    benchmark::DoNotOptimize(ret_val);
     benchmark::DoNotOptimize(msg);
     benchmark::DoNotOptimize(output);
 
-    ret_val &= hasher.absorb(msg);
-    ret_val &= hasher.finalize();
-    ret_val &= hasher.squeeze(output);
+    ascon_xof128::ascon_xof128_t hasher;
+    assert(hasher.absorb(msg) == ascon_xof128::ascon_xof128_status_t::absorbed_data);
+    assert(hasher.finalize() == ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+    assert(hasher.squeeze(output) == ascon_xof128::ascon_xof128_status_t::squeezed_output);
 
     benchmark::ClobberMemory();
   }
-
-  assert(ret_val);
 
   const size_t total_bytes_processed = (msg_byte_len + out_byte_len) * state.iterations();
   state.SetBytesProcessed(total_bytes_processed);

--- a/benches/bench_ascon_xof128.cpp
+++ b/benches/bench_ascon_xof128.cpp
@@ -42,8 +42,8 @@ bench_ascon_xof128(benchmark::State& state)
 BENCHMARK(bench_ascon_xof128)
   ->Name("ascon_xof128")
   ->ArgsProduct({
-    { 32, 256, 2'048, 16'384 }, // Input, to be absorbed
-    { 64, 512 }                 // Output, to be squeezed
+    { 32, 64, 2 * 1'048, 16 * 1'024 }, // Input, to be absorbed
+    { 64, 512 }                        // Output, to be squeezed
   })
   ->ComputeStatistics("min", compute_min)
   ->ComputeStatistics("max", compute_max);

--- a/examples/ascon_hash256.cpp
+++ b/examples/ascon_hash256.cpp
@@ -16,9 +16,9 @@ main()
   generate_random_data<uint8_t>(msg);
 
   ascon_hash256::ascon_hash256_t hasher;
-  assert(hasher.absorb(msg));
-  assert(hasher.finalize());
-  assert(hasher.digest(digest));
+  assert(hasher.absorb(msg) == ascon_hash256::ascon_hash256_status_t::absorbed_data);
+  assert(hasher.finalize() == ascon_hash256::ascon_hash256_status_t::finalized_data_absorption_phase);
+  assert(hasher.digest(digest) == ascon_hash256::ascon_hash256_status_t::message_digest_produced);
 
   std::cout << "Ascon-Hash256\n\n";
   std::cout << "Message :\t" << bytes_to_hex_string(msg) << "\n";

--- a/examples/ascon_xof128.cpp
+++ b/examples/ascon_xof128.cpp
@@ -16,9 +16,9 @@ main()
   generate_random_data<uint8_t>(msg);
 
   ascon_xof128::ascon_xof128_t hasher;
-  assert(hasher.absorb(msg));
-  assert(hasher.finalize());
-  assert(hasher.squeeze(out));
+  assert(hasher.absorb(msg) == ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  assert(hasher.finalize() == ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  assert(hasher.squeeze(out) == ascon_xof128::ascon_xof128_status_t::squeezed_output);
 
   std::cout << "Ascon-XOF128\n\n";
   std::cout << "Message :\t" << bytes_to_hex_string(msg) << "\n";

--- a/include/ascon/hashes/ascon_hash256.hpp
+++ b/include/ascon/hashes/ascon_hash256.hpp
@@ -14,6 +14,58 @@ static constexpr auto INITIAL_PERMUTATION_STATE = ascon_sponge_mode::compute_ini
                                                                                                                        ascon_sponge_mode::RATE_BYTES));
 
 /**
+ * @brief Enumerates the possible status results of Ascon-Hash256 operations.
+ *
+ * These status codes indicate the result of calling methods like `absorb`, `finalize`, and `digest`,
+ * reflecting the current state of the hashing process (e.g., whether data was absorbed, if
+ * the absorption phase is finished, or if the digest has been produced).
+ */
+enum class ascon_hash256_status_t : uint8_t
+{
+  /**
+   * @brief Indicates that data was successfully absorbed into the hash state.
+   *
+   * Returned by the `absorb` method when input data is successfully processed.
+   */
+  absorbed_data = 0x01,
+
+  /**
+   * @brief Indicates that the data absorption phase is still ongoing.
+   *
+   * Returned by the `digest` method if called before `finalize` has been successfully called.
+   */
+  still_in_data_absorption_phase,
+
+  /**
+   * @brief Indicates that the data absorption phase was successfully finalized.
+   *
+   * Returned by the `finalize` method when the absorption phase is successfully completed for the first time.
+   */
+  finalized_data_absorption_phase,
+
+  /**
+   * @brief Indicates that the data absorption phase has already been finalized.
+   *
+   * Returned by the `absorb` or `finalize` methods if called after `finalize` has already been successfully called.
+   */
+  data_absorption_phase_already_finalized,
+
+  /**
+   * @brief Indicates that the message digest was successfully produced.
+   *
+   * Returned by the `digest` method when the final hash value is successfully computed and written to the output buffer for the first time.
+   */
+  message_digest_produced,
+
+  /**
+   * @brief Indicates that the message digest has already been produced.
+   *
+   * Returned by the `digest` method if called after the digest has already been successfully produced in a previous call.
+   */
+  message_digest_already_produced,
+};
+
+/**
  * @brief Represents the Ascon-Hash256 hashing algorithm.
  *
  * This struct encapsulates the state and methods for computing the Ascon-Hash256 hash of a message. It uses the Ascon permutation and a sponge construction.
@@ -50,39 +102,42 @@ public:
    * function. This function can be called multiple times to absorb data in chunks; only after calling `finalize()` will further calls to `absorb` be ignored.
    *
    * @param msg A span of bytes representing the data to absorb.
-   * @return `true` if the data was successfully absorbed, `false` if the hash state has already been finalized.
+   * @return An `ascon_hash256_status_t` indicating if data was successfully absorbed (`ascon_hash256_status_t::absorbed_data`)
+   * or if the data absorption phase was already finalized (`ascon_hash256_status_t::data_absorption_phase_already_finalized`).
    */
   [[nodiscard]]
-  forceinline constexpr bool absorb(std::span<const uint8_t> msg)
+  forceinline constexpr ascon_hash256_status_t absorb(std::span<const uint8_t> msg)
   {
-    if (!finished_absorbing) [[likely]] {
-      ascon_sponge_mode::absorb(state, offset, msg);
-      return true;
+    if (finished_absorbing) {
+      return ascon_hash256_status_t::data_absorption_phase_already_finalized;
     }
 
-    return false;
+    ascon_sponge_mode::absorb(state, offset, msg);
+    return ascon_hash256_status_t::absorbed_data;
   }
 
   /**
    * @brief Finalizes the hash computation.
    *
    * This function finalizes the hash computation by padding the message and performing the necessary final transformations within the Ascon sponge
-   * construction.  It must be called before calling `digest()` to obtain the final hash value.  Calling this function multiple times has no effect.
+   * construction. It must be called before calling `digest()` to obtain the final hash value. Calling this function multiple times has no effect.
    * Subsequent calls to `absorb` after calling `finalize` will be ignored.
    *
-   * @return `true` if the function successfully finalized the hash computation (meaning it was called before and not after `digest`), `false` otherwise.
+   * @return An `ascon_hash256_status_t` indicating if the data absorption phase was successfully finalized
+   * (`ascon_hash256_status_t::finalized_data_absorption_phase`) or if it was already finalized
+   * (`ascon_hash256_status_t::data_absorption_phase_already_finalized`).
    */
   [[nodiscard]]
-  forceinline constexpr bool finalize()
+  forceinline constexpr ascon_hash256_status_t finalize()
   {
-    if (!finished_absorbing) [[likely]] {
-      ascon_sponge_mode::finalize(state, offset);
-      finished_absorbing = true;
-
-      return true;
+    if (finished_absorbing) {
+      return ascon_hash256_status_t::data_absorption_phase_already_finalized;
     }
 
-    return false;
+    ascon_sponge_mode::finalize(state, offset);
+    finished_absorbing = true;
+
+    return ascon_hash256_status_t::finalized_data_absorption_phase;
   }
 
   /**
@@ -92,20 +147,25 @@ public:
    * successfully extract and return the digest; subsequent calls will only return `false`.
    *
    * @param out A span of bytes where the resulting digest will be written.  The span must be large enough to hold a digest of `DIGEST_BYTE_LEN` bytes.
-   * @return `true` if the digest was successfully extracted (this is the first call after `finalize()`), `false` otherwise.
+   * @return An `ascon_hash256_status_t` indicating if the message digest was successfully produced (`ascon_hash256_status_t::message_digest_produced`), if the
+   * data absorption phase has not yet been finalized (`ascon_hash256_status_t::still_in_data_absorption_phase`), or if the message digest has already been
+   * produced (`ascon_hash256_status_t::message_digest_already_produced`).
    */
   [[nodiscard]]
-  forceinline constexpr bool digest(std::span<uint8_t, DIGEST_BYTE_LEN> out)
+  forceinline constexpr ascon_hash256_status_t digest(std::span<uint8_t, DIGEST_BYTE_LEN> out)
   {
-    if (finished_absorbing && !finished_squeezing) [[likely]] {
-      size_t readable = ascon_sponge_mode::RATE_BYTES;
-      ascon_sponge_mode::squeeze(state, readable, out);
-
-      finished_squeezing = true;
-      return true;
+    if (!finished_absorbing) {
+      return ascon_hash256_status_t::still_in_data_absorption_phase;
+    }
+    if (finished_squeezing) {
+      return ascon_hash256_status_t::message_digest_already_produced;
     }
 
-    return false;
+    size_t readable = ascon_sponge_mode::RATE_BYTES;
+    ascon_sponge_mode::squeeze(state, readable, out);
+
+    finished_squeezing = true;
+    return ascon_hash256_status_t::message_digest_produced;
   }
 };
 

--- a/include/ascon/hashes/ascon_hash256.hpp
+++ b/include/ascon/hashes/ascon_hash256.hpp
@@ -165,6 +165,8 @@ public:
     ascon_sponge_mode::squeeze(state, readable, out);
 
     finished_squeezing = true;
+    this->state.reset();
+
     return ascon_hash256_status_t::message_digest_produced;
   }
 };

--- a/tests/kat_ascon_hash256.cpp
+++ b/tests/kat_ascon_hash256.cpp
@@ -33,9 +33,9 @@ TEST(AsconHash256, KnownAnswerTests)
       std::array<uint8_t, ascon_hash256::DIGEST_BYTE_LEN> computed_md{};
 
       ascon_hash256::ascon_hash256_t hasher;
-      EXPECT_TRUE(hasher.absorb(msg));
-      EXPECT_TRUE(hasher.finalize());
-      EXPECT_TRUE(hasher.digest(computed_md));
+      EXPECT_EQ(hasher.absorb(msg), ascon_hash256::ascon_hash256_status_t::absorbed_data);
+      EXPECT_EQ(hasher.finalize(), ascon_hash256::ascon_hash256_status_t::finalized_data_absorption_phase);
+      EXPECT_EQ(hasher.digest(computed_md), ascon_hash256::ascon_hash256_status_t::message_digest_produced);
 
       EXPECT_TRUE(std::ranges::equal(computed_md, md));
 

--- a/tests/kat_ascon_xof128.cpp
+++ b/tests/kat_ascon_xof128.cpp
@@ -32,9 +32,9 @@ TEST(AsconXof128, KnownAnswerTests)
       std::vector<uint8_t> computed_md(md.size());
 
       ascon_xof128::ascon_xof128_t hasher;
-      EXPECT_TRUE(hasher.absorb(msg));
-      EXPECT_TRUE(hasher.finalize());
-      EXPECT_TRUE(hasher.squeeze(computed_md));
+      EXPECT_EQ(hasher.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+      EXPECT_EQ(hasher.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+      EXPECT_EQ(hasher.squeeze(computed_md), ascon_xof128::ascon_xof128_status_t::squeezed_output);
 
       EXPECT_EQ(computed_md, md);
 

--- a/tests/prop_test_ascon_hash256.cpp
+++ b/tests/prop_test_ascon_hash256.cpp
@@ -17,9 +17,9 @@ eval_ascon_hash256()
   std::array<uint8_t, ascon_hash256::DIGEST_BYTE_LEN> md{};
 
   ascon_hash256::ascon_hash256_t hasher;
-  assert(hasher.absorb(data));
-  assert(hasher.finalize());
-  assert(hasher.digest(md));
+  assert(hasher.absorb(data) == ascon_hash256::ascon_hash256_status_t::absorbed_data);
+  assert(hasher.finalize() == ascon_hash256::ascon_hash256_status_t::finalized_data_absorption_phase);
+  assert(hasher.digest(md) == ascon_hash256::ascon_hash256_status_t::message_digest_produced);
 
   // Returns hex-encoded digest.
   return bytes_to_hex(md);
@@ -59,9 +59,9 @@ TEST(AsconHash256, ForSameMessageOneshotHashingAndIncrementalHashingProducesSame
     {
       ascon_hash256::ascon_hash256_t hasher;
 
-      EXPECT_TRUE(hasher.absorb(msg_span));
-      EXPECT_TRUE(hasher.finalize());
-      EXPECT_TRUE(hasher.digest(digest_oneshot));
+      EXPECT_EQ(hasher.absorb(msg_span), ascon_hash256::ascon_hash256_status_t::absorbed_data);
+      EXPECT_EQ(hasher.finalize(), ascon_hash256::ascon_hash256_status_t::finalized_data_absorption_phase);
+      EXPECT_EQ(hasher.digest(digest_oneshot), ascon_hash256::ascon_hash256_status_t::message_digest_produced);
     }
 
     // Incremental hashing
@@ -73,12 +73,12 @@ TEST(AsconHash256, ForSameMessageOneshotHashingAndIncrementalHashingProducesSame
         // Because we don't want to be stuck in an infinite loop if msg[msg_offset] = 0
         const auto elen = std::min<size_t>(std::max<uint8_t>(msg[msg_offset], 1), msg_byte_len - msg_offset);
 
-        EXPECT_TRUE(hasher.absorb(msg_span.subspan(msg_offset, elen)));
+        EXPECT_EQ(hasher.absorb(msg_span.subspan(msg_offset, elen)), ascon_hash256::ascon_hash256_status_t::absorbed_data);
         msg_offset += elen;
       }
 
-      EXPECT_TRUE(hasher.finalize());
-      EXPECT_TRUE(hasher.digest(digest_multishot));
+      EXPECT_EQ(hasher.finalize(), ascon_hash256::ascon_hash256_status_t::finalized_data_absorption_phase);
+      EXPECT_EQ(hasher.digest(digest_multishot), ascon_hash256::ascon_hash256_status_t::message_digest_produced);
     }
 
     EXPECT_EQ(digest_oneshot, digest_multishot);

--- a/tests/prop_test_ascon_xof128.cpp
+++ b/tests/prop_test_ascon_xof128.cpp
@@ -18,9 +18,9 @@ eval_ascon_xof128()
   std::array<uint8_t, olen> md{};
 
   ascon_xof128::ascon_xof128_t hasher;
-  assert(hasher.absorb(data));
-  assert(hasher.finalize());
-  assert(hasher.squeeze(md));
+  assert(hasher.absorb(data) == ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  assert(hasher.finalize() == ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  assert(hasher.squeeze(md) == ascon_xof128::ascon_xof128_status_t::squeezed_output);
 
   // Returns hex-encoded digest.
   return bytes_to_hex(md);
@@ -60,9 +60,9 @@ TEST(AsconXof128, ForSameMessageOneshotHashingAndIncrementalHashingProducesSameO
       {
         ascon_xof128::ascon_xof128_t hasher;
 
-        EXPECT_TRUE(hasher.absorb(msg_span));
-        EXPECT_TRUE(hasher.finalize());
-        EXPECT_TRUE(hasher.squeeze(digest_oneshot_span));
+        EXPECT_EQ(hasher.absorb(msg_span), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+        EXPECT_EQ(hasher.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+        EXPECT_EQ(hasher.squeeze(digest_oneshot_span), ascon_xof128::ascon_xof128_status_t::squeezed_output);
       }
 
       // Incremental hashing
@@ -74,21 +74,21 @@ TEST(AsconXof128, ForSameMessageOneshotHashingAndIncrementalHashingProducesSameO
           // Because we don't want to be stuck in an infinite loop if msg[off] = 0
           const auto elen = std::min<size_t>(std::max<uint8_t>(msg_span[msg_offset], 1), msg_byte_len - msg_offset);
 
-          EXPECT_TRUE(hasher.absorb(msg_span.subspan(msg_offset, elen)));
+          EXPECT_EQ(hasher.absorb(msg_span.subspan(msg_offset, elen)), ascon_xof128::ascon_xof128_status_t::absorbed_data);
           msg_offset += elen;
         }
 
-        EXPECT_TRUE(hasher.finalize());
+        EXPECT_EQ(hasher.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
 
         // Squeeze message bytes in many iterations
         size_t output_offset = 0;
         while (output_offset < output_byte_len) {
-          EXPECT_TRUE(hasher.squeeze(digest_multishot_span.subspan(output_offset, 1)));
+          EXPECT_EQ(hasher.squeeze(digest_multishot_span.subspan(output_offset, 1)), ascon_xof128::ascon_xof128_status_t::squeezed_output);
 
           auto elen = std::min<size_t>(digest_multishot_span[output_offset], output_byte_len - (output_offset + 1));
 
           output_offset += 1;
-          EXPECT_TRUE(hasher.squeeze(digest_multishot_span.subspan(output_offset, elen)));
+          EXPECT_EQ(hasher.squeeze(digest_multishot_span.subspan(output_offset, elen)), ascon_xof128::ascon_xof128_status_t::squeezed_output);
           output_offset += elen;
         }
       }

--- a/tests/prop_test_ascon_xof128.cpp
+++ b/tests/prop_test_ascon_xof128.cpp
@@ -97,3 +97,105 @@ TEST(AsconXof128, ForSameMessageOneshotHashingAndIncrementalHashingProducesSameO
     }
   }
 }
+
+TEST(AsconXof128, ValidXofSequence)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+}
+
+TEST(AsconXof128, MultipleAbsorbCalls)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+}
+
+TEST(AsconXof128, MultipleFinalizeCalls)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::data_absorption_phase_already_finalized);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+}
+
+TEST(AsconXof128, MultipleSqueezeCalls)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+}
+
+TEST(AsconXof128, AbsorbMessageAfterFinalize)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::data_absorption_phase_already_finalized);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+}
+
+TEST(AsconXof128, AbsorbMessageDuringSqueezing)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::data_absorption_phase_already_finalized);
+}
+
+TEST(AsconXof128, FinalizeDuringSqueezing)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::data_absorption_phase_already_finalized);
+}
+
+TEST(AsconXof128, FinalizeWithoutAbsorb)
+{
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.finalize(), ascon_xof128::ascon_xof128_status_t::finalized_data_absorption_phase);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::squeezed_output);
+}
+
+TEST(AsconXof128, SqueezeWithoutFinalize)
+{
+  std::array<uint8_t, 16> msg{};
+  std::array<uint8_t, 32> output{};
+
+  ascon_xof128::ascon_xof128_t xof;
+  EXPECT_EQ(xof.absorb(msg), ascon_xof128::ascon_xof128_status_t::absorbed_data);
+  EXPECT_EQ(xof.squeeze(output), ascon_xof128::ascon_xof128_status_t::still_in_data_absorption_phase);
+}


### PR DESCRIPTION
- Introduce status enum for denoting member-function execution result for following
	- [x] Ascon-Hash256
	- [x] Ascon-Xof128
	- [ ] Ascon-CXof128

- [x] Add tests to ensure that state transition works as expected.
- [x] Update existing examples, tests and benchmarks.
- [ ] Update documentation.
